### PR TITLE
Change ifconfig command to use $BR_IFACE

### DIFF
--- a/mitmrouter.sh
+++ b/mitmrouter.sh
@@ -79,7 +79,7 @@ if [ $1 = "up" ]; then
     
     
     echo "== setting static IP on bridge interface"
-    sudo ifconfig br0 inet $LAN_IP netmask $LAN_SUBNET
+    sudo ifconfig $BR_IFACE inet $LAN_IP netmask $LAN_SUBNET
     
     echo "== starting dnsmasq"
     sudo dnsmasq -C $DNSMASQ_CONF


### PR DESCRIPTION
Current implementation hardcodes "br0" into the final ifconfig command. 

PR simply changes to use variable bridge name set at the top of the script.